### PR TITLE
Feat: 휴가 정책 연도별 조회 기능 구현

### DIFF
--- a/src/main/java/com/pado/inflow/vacation/query/controller/VacationPolicyController.java
+++ b/src/main/java/com/pado/inflow/vacation/query/controller/VacationPolicyController.java
@@ -1,7 +1,26 @@
 package com.pado.inflow.vacation.query.controller;
 
-import org.springframework.web.bind.annotation.RestController;
+import com.pado.inflow.vacation.query.dto.VacationPolicyDTO;
+import com.pado.inflow.vacation.query.service.VacationPolicyService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController("queryVacationPolicyController")
+@RequestMapping("/api/vacation/policies")
 public class VacationPolicyController {
+
+    private final VacationPolicyService vacationPolicyService;
+
+    @Autowired
+    public VacationPolicyController(VacationPolicyService vacationPolicyService) {
+        this.vacationPolicyService = vacationPolicyService;
+    }
+
+    @GetMapping
+    public List<VacationPolicyDTO> getVacationPoliciesByYear(@RequestParam("year") Integer year) {
+        return vacationPolicyService.findVacationPoliciesByYear(year);
+    }
+
 }

--- a/src/main/java/com/pado/inflow/vacation/query/controller/VacationTypeController.java
+++ b/src/main/java/com/pado/inflow/vacation/query/controller/VacationTypeController.java
@@ -18,6 +18,7 @@ public class VacationTypeController {
         this.vacationTypeService = vacationTypeService;
     }
 
+    // 휴가 종류 전체 조회
     @GetMapping()
     public List<VacationTypeDTO> getVacationTypes() {
         return vacationTypeService.findVacationTypes();

--- a/src/main/java/com/pado/inflow/vacation/query/repository/VacationPolicyMapper.java
+++ b/src/main/java/com/pado/inflow/vacation/query/repository/VacationPolicyMapper.java
@@ -1,7 +1,14 @@
 package com.pado.inflow.vacation.query.repository;
 
+import com.pado.inflow.vacation.query.dto.VacationPolicyDTO;
 import org.apache.ibatis.annotations.Mapper;
+
+import java.util.List;
 
 @Mapper
 public interface VacationPolicyMapper {
+
+    // 연도별 휴가 정책 조회
+    List<VacationPolicyDTO> findVacationPoliciesByYear(Integer year);
+
 }

--- a/src/main/java/com/pado/inflow/vacation/query/service/VacationPolicyService.java
+++ b/src/main/java/com/pado/inflow/vacation/query/service/VacationPolicyService.java
@@ -1,4 +1,12 @@
 package com.pado.inflow.vacation.query.service;
 
+import com.pado.inflow.vacation.query.dto.VacationPolicyDTO;
+
+import java.util.List;
+
 public interface VacationPolicyService {
+
+    // 연도별 휴가 정책 조회
+    List<VacationPolicyDTO> findVacationPoliciesByYear(Integer year);
+
 }

--- a/src/main/java/com/pado/inflow/vacation/query/service/VacationPolicyServiceImpl.java
+++ b/src/main/java/com/pado/inflow/vacation/query/service/VacationPolicyServiceImpl.java
@@ -1,7 +1,28 @@
 package com.pado.inflow.vacation.query.service;
 
+import com.pado.inflow.vacation.query.dto.VacationPolicyDTO;
+import com.pado.inflow.vacation.query.repository.VacationPolicyMapper;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+
 @Service
-public class VacationPolicyServiceImpl {
+public class VacationPolicyServiceImpl implements VacationPolicyService {
+
+    private final VacationPolicyMapper vacationPolicyMapper;
+
+    public VacationPolicyServiceImpl(VacationPolicyMapper vacationPolicyMapper) {
+        this.vacationPolicyMapper = vacationPolicyMapper;
+    }
+
+    // 연도별 휴가 정책 조회
+    @Override
+    public List<VacationPolicyDTO> findVacationPoliciesByYear(Integer year) {
+        List<VacationPolicyDTO> vacationPolicies = vacationPolicyMapper.findVacationPoliciesByYear(year);
+//        if (vacationPolicies == null || vacationPolicies.isEmpty()) {
+//            throw new
+//        }
+        return vacationPolicies;
+    }
+
 }

--- a/src/main/resources/com/pado/inflow/vacation/query/repository/VacationPolicyMapper.xml
+++ b/src/main/resources/com/pado/inflow/vacation/query/repository/VacationPolicyMapper.xml
@@ -1,0 +1,32 @@
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.pado.inflow.vacation.query.repository.VacationPolicyMapper">
+    <resultMap id="vacationPolicyResultMap" type="com.pado.inflow.vacation.query.dto.VacationPolicyDTO">
+        <id property="vacationPolicyId" column="VACATION_POLICY_ID"/>
+        <result property="vacationPolicyName" column="VACATION_POLICY_NAME"/>
+        <result property="allocationDays" column="ALLOCATION_DAYS"/>
+        <result property="paidStatus" column="PAID_STATUS"/>
+        <result property="year" column="YEAR"/>
+        <result property="createdAt" column="CREATED_AT"/>
+        <result property="autoAllocationCycle" column="AUTO_ALLOCATION_CYCLE"/>
+        <result property="vacationTypeName" column="VACATION_TYPE_NAME"/>
+    </resultMap>
+
+    <select id="findVacationPoliciesByYear" resultMap="vacationPolicyResultMap" parameterType="Integer">
+        SELECT
+               A.VACATION_POLICY_ID
+             , A.VACATION_POLICY_NAME
+             , A.ALLOCATION_DAYS
+             , A.PAID_STATUS
+             , A.YEAR
+             , A.CREATED_AT
+             , A.AUTO_ALLOCATION_CYCLE
+             , B.VACATION_TYPE_NAME
+          FROM VACATION_POLICY A
+          JOIN VACATION_TYPE B
+            ON A.VACATION_TYPE_ID = B.VACATION_TYPE_ID
+         WHERE A.YEAR = #{ year }
+         ORDER BY A.VACATION_POLICY_ID
+    </select>
+</mapper>

--- a/src/test/java/com/pado/inflow/vacation/query/service/VacationPolicyServiceTests.java
+++ b/src/test/java/com/pado/inflow/vacation/query/service/VacationPolicyServiceTests.java
@@ -1,0 +1,39 @@
+package com.pado.inflow.vacation.query.service;
+
+import com.pado.inflow.vacation.query.dto.VacationPolicyDTO;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Slf4j
+@SpringBootTest
+@Transactional
+class VacationPolicyServiceTests {
+
+    @Autowired
+    private VacationPolicyService vacationPolicyService;
+
+    @DisplayName("연도별 휴가 정책 조회 테스트")
+    @Test
+    void testFindVacationPoliciesByYear() {
+        // Given
+        Integer year = 2024;
+
+        // When
+        List<VacationPolicyDTO> vacationPolicies = vacationPolicyService.findVacationPoliciesByYear(year);
+
+        if (vacationPolicies != null && !vacationPolicies.isEmpty()) {
+            vacationPolicies.forEach(x -> log.info(x.toString()));
+        }
+
+        // Then
+        Assertions.assertNotNull(vacationPolicies);
+    }
+
+}


### PR DESCRIPTION
---
name: 기능 개발 이슈
assignees: @woodart8 

---

## 무슨 이유로 코드를 개발했는가
- [x] 신규 기능
- [ ] 기능 수정
- [ ] 버그 픽스
- [ ] 테스트

## 관련 스크린 샷 
![image](https://github.com/user-attachments/assets/cf005674-40a4-4e70-a03f-c09d1768945a)


## 테스트 계획 또는 완료 사항(테스트인 경우)
- [x] 휴가 정책이 연도별로 조회되는가?

## 소스코드1
```Java
    @DisplayName("연도별 휴가 정책 조회 테스트")
    @Test
    void testFindVacationPoliciesByYear() {
        // Given
        Integer year = 2024;

        // When
        List<VacationPolicyDTO> vacationPolicies = vacationPolicyService.findVacationPoliciesByYear(year);

        if (vacationPolicies != null && !vacationPolicies.isEmpty()) {
            vacationPolicies.forEach(x -> log.info(x.toString()));
        }

        // Then
        Assertions.assertNotNull(vacationPolicies);
    }
```

## 닫은 이슈(기능)
close #8 
