### PR TITLE
Fix: 마이바티스와 Optional 기본인식 문제로 인한 버그 해결

### DIFF
--- a/src/main/java/com/pado/inflow/employee/info/query/repository/EmployeeMapper.java
+++ b/src/main/java/com/pado/inflow/employee/info/query/repository/EmployeeMapper.java
@@ -11,10 +11,10 @@ import java.util.Optional;
 public interface EmployeeMapper {
 
     // 설명.1. 전체 사원 조회
-    Optional<List<EmployeeDTO>> findAllEmployees();
+   List<EmployeeDTO> findAllEmployees();
 
     // 설명.2. 이름으로 사원 조회
-    Optional<List<EmployeeDTO>> findEmployeesByName(@Param("name") String name);
+   List<EmployeeDTO> findEmployeesByName(@Param("name") String name);
 
     // 설명.3. 사번으로 사원 조회
     Optional<EmployeeDTO> findEmployeeByNumber(@Param("employeeNumber") String employeeNumber);

--- a/src/main/java/com/pado/inflow/employee/info/query/service/EmployeeServiceImpl.java
+++ b/src/main/java/com/pado/inflow/employee/info/query/service/EmployeeServiceImpl.java
@@ -21,15 +21,21 @@ public class EmployeeServiceImpl implements EmployeeService {
     // 1.1. 설명: 사원 리스트 전체 조회
     @Override
     public List<EmployeeDTO> getAllEmployees() {
-        return employeeMapper.findAllEmployees()
-                .orElseThrow(() -> new CommonException(ErrorCode.NOT_FOUND_EMPLOYEE));
+        List<EmployeeDTO> employees = employeeMapper.findAllEmployees();
+        if (employees.isEmpty()) {
+            throw new CommonException(ErrorCode.NOT_FOUND_EMPLOYEE);
+        }
+        return employees;
     }
 
     // 1.2. 설명: 사원 리스트 이름으로 조회
     @Override
     public List<EmployeeDTO> getEmployeesByName(String name) {
-        return employeeMapper.findEmployeesByName(name)
-                .orElseThrow(() -> new CommonException(ErrorCode.NOT_FOUND_EMPLOYEE));
+        List<EmployeeDTO> employees = employeeMapper.findEmployeesByName(name);
+        if (employees.isEmpty()) {
+            throw new CommonException(ErrorCode.NOT_FOUND_EMPLOYEE);
+        }
+        return employees;
     }
 
     // 1.3. 설명: 사원 정보 사번으로 조회

--- a/src/main/resources/com/pado/inflow/employee/info/query/repository/EmployeeMapper.xml
+++ b/src/main/resources/com/pado/inflow/employee/info/query/repository/EmployeeMapper.xml
@@ -69,7 +69,7 @@
     </select>
 
     <!-- 사번으로 사원 조회 -->
-    <select id="findEmployeeByNumber" parameterType="String" resultType="com.pado.inflow.employee.info.query.dto.EmployeeDTO">
+    <select id="findEmployeeByNumber" parameterType="String" resultType="com.pado.inflow.employee.info.query.dto.EmployeeDTO" resultSetType="FORWARD_ONLY">
         SELECT
             employee_id AS employeeId,
             employee_number AS employeeNumber,
@@ -101,7 +101,7 @@
     </select>
 
     <!-- ID로 사원 조회 -->
-    <select id="findEmployeeById" parameterType="Long" resultType="com.pado.inflow.employee.info.query.dto.EmployeeDTO">
+    <select id="findEmployeeById" parameterType="Long" resultType="com.pado.inflow.employee.info.query.dto.EmployeeDTO" resultSetType="FORWARD_ONLY">
         SELECT
             employee_id AS employeeId,
             employee_number AS employeeNumber,


### PR DESCRIPTION
---
name: Fix: 마이바티스와 Optional 기본인식 문제로 인한 버그 해결
assignees: '조창욱'

---


## 상세 설명
- Optional을 사용하는 자체는 문제가 되지 않지만, MyBatis와 함께 Optional<List<EmployeeDTO>> 형태로 반환하려고 할 때 TooManyResultsException이 발생하는 경우가 있다. 
- 그 이유는 MyBatis가 Optional을 다룰 때 기본적으로 단일 객체 조회를 위한 selectOne 방식으로 해석하기 때문이다.

