### PR TITLE
Feat : 과제 유형 삭제

### DIFF
--- a/src/main/java/com/pado/inflow/common/exception/ErrorCode.java
+++ b/src/main/java/com/pado/inflow/common/exception/ErrorCode.java
@@ -20,7 +20,8 @@ public enum ErrorCode {
     MISSING_REQUIRED_FIELD(40012, HttpStatus.BAD_REQUEST, "필수 필드가 누락되었습니다."), // JSON 또는 요청 데이터에서 필수 필드가 누락된 경우
     INVALID_VERIFICATION_CODE(40013, HttpStatus.BAD_REQUEST, "잘못된 인증번호입니다. 인증번호를 다시 확인해주세요"), // 인증번호가 잘못되었거나 유효하지 않은 경우
     INSUFFICIENT_VACATION_DAYS(40014, HttpStatus.BAD_REQUEST, "휴가일수가 부족합니다."), // 휴가 신청 시 잔여 휴가일이 부족한 경우
-
+    TASK_TYPE_UPDATE_FAILURE(40015, HttpStatus.BAD_REQUEST, "이미 해당 과제 유형이 사용중이므로 업데이트가 불가능합니다."),
+    TASK_TYPE_DELETE_FAILURE(40016, HttpStatus.BAD_REQUEST,"해당 과제 유형이 사용중이므로 삭제할수 없습니다."),
     // 파일 관련 오류
     UNSUPPORTED_FILE_FORMAT(40020, HttpStatus.BAD_REQUEST, "지원되지 않는 파일 형식입니다."), // 업로드된 파일의 형식이 지원되지 않는 경우
     FILE_UPLOAD_ERROR(40021, HttpStatus.BAD_REQUEST, "파일 업로드에 실패했습니다."), // 파일 업로드 중 오류 발생
@@ -42,7 +43,6 @@ public enum ErrorCode {
     EXIST_USER(40112, HttpStatus.UNAUTHORIZED, "이미 회원가입한 회원입니다."), // 이미 회원가입된 사용자
     NOT_FOUND_USER_ID(40113, HttpStatus.UNAUTHORIZED, "아이디를 잘못 입력하셨습니다."), // 잘못된 아이디 입력
     INVALID_PASSWORD(40114, HttpStatus.UNAUTHORIZED, "비밀번호를 잘못 입력하셨습니다."), // 비밀번호가 잘못된 경우
-    UPDATE_FAILURE(40015, HttpStatus.BAD_REQUEST, "이미 해당 과제 유형이 사용중이므로 업데이트가 불가능합니다."),
 
     // 403: 권한 부족 (Forbidden)
     FORBIDDEN_ROLE(40300, HttpStatus.FORBIDDEN, "요청한 리소스에 대한 권한이 없습니다."), // 사용자가 요청한 리소스에 대한 권한이 없는 경우

--- a/src/main/java/com/pado/inflow/employee/security/WebSecurity.java
+++ b/src/main/java/com/pado/inflow/employee/security/WebSecurity.java
@@ -98,12 +98,36 @@ public class WebSecurity {
                     .requestMatchers(new AntPathRequestMatcher("/api/vacations/**", "PUT")).hasAnyRole("EMPLOYEE", "HR", "MANAGER", "ADMIN")
                     .requestMatchers(new AntPathRequestMatcher("/api/vacations/**", "PATCH")).hasAnyRole("EMPLOYEE", "HR", "MANAGER", "ADMIN")
 
+                    /* -------------------------------------------------------------------------------------------------------------------------------------------------------------- */
                     // 설명. 6. evaluation(평가) 도메인
-                    .requestMatchers(new AntPathRequestMatcher("/api/evaluations/**", "GET")).hasAnyRole("EMPLOYEE", "HR", "MANAGER", "ADMIN")
-                    .requestMatchers(new AntPathRequestMatcher("/api/evaluations/**", "POST")).hasAnyRole("EMPLOYEE", "HR", "MANAGER", "ADMIN")
-                    .requestMatchers(new AntPathRequestMatcher("/api/evaluations/**", "DELETE")).hasAnyRole("EMPLOYEE", "HR", "MANAGER", "ADMIN")
-                    .requestMatchers(new AntPathRequestMatcher("/api/evaluations/**", "PUT")).hasAnyRole("EMPLOYEE", "HR", "MANAGER", "ADMIN")
-                    .requestMatchers(new AntPathRequestMatcher("/api/evaluations/**", "PATCH")).hasAnyRole("EMPLOYEE", "HR", "MANAGER", "ADMIN")
+
+                    // 과제 유형 ( Task_Type )
+                    .requestMatchers(new AntPathRequestMatcher("/api/evaluations/taskType/allTaskType", "GET")).hasAnyRole(    "EMPLOYEE", "HR", "MANAGER", "ADMIN")
+                    .requestMatchers(new AntPathRequestMatcher("/api/evaluations/taskType/create", "POST")).hasAnyRole(   "HR", "ADMIN")
+                    .requestMatchers(new AntPathRequestMatcher("/api/evaluations/taskType/**", "PATCH")).hasAnyRole(  "HR", "ADMIN")
+                    .requestMatchers(new AntPathRequestMatcher("/api/evaluations/taskType/**", "DELETE")).hasAnyRole( "HR", "ADMIN")
+
+                    // 과제 항목 ( Task_Item )
+                    .requestMatchers(new AntPathRequestMatcher("/api/evaluations/taskItem/departmentTask", "GET")).hasAnyRole("MANAGER", "ADMIN")
+                    .requestMatchers(new AntPathRequestMatcher("/api/evaluations/taskItem/individualTasks", "GET")).hasAnyRole("EMPLOYEE", "HR", "MANAGER", "ADMIN")
+                    .requestMatchers(new AntPathRequestMatcher("/api/evaluations/taskItem/individualTask/**", "GET")).hasAnyRole("EMPLOYEE", "HR", "MANAGER", "ADMIN")
+                    .requestMatchers(new AntPathRequestMatcher("/api/evaluations/taskItem/commonTasks", "GET")).hasAnyRole("HR", "ADMIN")
+
+                    // 과제별 평가 ( Task_Eval )
+                    .requestMatchers(new AntPathRequestMatcher("/api/evaluations/taskEval/**", "GET")).hasAnyRole("EMPLOYEE", "HR", "MANAGER", "ADMIN")
+
+                    // 평가 등급 ( grade )
+                    .requestMatchers(new AntPathRequestMatcher("/api/evaluations/grade/**", "GET")).hasAnyRole("HR", "ADMIN")
+
+                    // 평가 피드백 ( feedback )
+                    .requestMatchers(new AntPathRequestMatcher("/api/evaluations/feedback/**", "GET")).hasAnyRole("EMPLOYEE", "HR", "MANAGER", "ADMIN")
+
+                    // 평가 정책 ( EvaluationPolicy )
+                    .requestMatchers(new AntPathRequestMatcher("/api/evaluations/evaluationPolicy/**", "GET")).hasAnyRole("HR", "ADMIN")
+
+                    // 평가 ( Evaluation )
+                    .requestMatchers(new AntPathRequestMatcher("/api/evaluations/evaluation/**", "GET")).hasAnyRole("EMPLOYEE", "HR", "MANAGER", "ADMIN")
+                    /* -------------------------------------------------------------------------------------------------------------------------------------------------------------- */
 
                     // 설명. 7. payroll(급여) 도메인
                     .requestMatchers(new AntPathRequestMatcher("/api/payrolls/**", "GET")).hasAnyRole("EMPLOYEE", "HR", "MANAGER", "ADMIN")

--- a/src/main/java/com/pado/inflow/evaluation/command/application/controller/TaskTypeController.java
+++ b/src/main/java/com/pado/inflow/evaluation/command/application/controller/TaskTypeController.java
@@ -5,6 +5,7 @@ import com.pado.inflow.evaluation.command.application.service.TaskTypeService;
 import com.pado.inflow.evaluation.command.domain.aggregate.dto.request.CreateTaskTypeRequestDTO;
 import com.pado.inflow.evaluation.command.domain.aggregate.dto.request.UpdateTaskTypeRequestDTO;
 import com.pado.inflow.evaluation.command.domain.aggregate.dto.response.CreateTaskTypeResponseDTO;
+import com.pado.inflow.evaluation.command.domain.aggregate.dto.response.DeleteTaskTypeResponseDTO;
 import com.pado.inflow.evaluation.command.domain.aggregate.dto.response.UpdateTaskTypeResponseDTO;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -12,7 +13,7 @@ import org.springframework.web.bind.annotation.*;
 
 @Slf4j
 @RestController("CommandTaskTypeController")
-@RequestMapping("/api/evaluation/taskTypes")        // 리소스 나타낼 때 복수형 사용하기
+@RequestMapping("/api/evaluations/taskType")        // 리소스 나타낼 때 복수형 사용하기
 public class TaskTypeController {
 
     @Autowired
@@ -22,7 +23,7 @@ public class TaskTypeController {
         this.taskTypeService = taskTypeService;
     }
 
-
+    // 과제 유형 생성
     @PostMapping("/create")
     public ResponseDTO<CreateTaskTypeResponseDTO> createTaskTypeByTaskTypeName(
             @RequestBody CreateTaskTypeRequestDTO CreateTaskTypeRequestDTO
@@ -32,6 +33,7 @@ public class TaskTypeController {
         return ResponseDTO.ok(createdTaskType);
     }
 
+    // 과제 유형 수정
     @PatchMapping("/{taskTypeId}")
     public ResponseDTO<UpdateTaskTypeResponseDTO> updateTaskTypeByTaskTypeId(
             @PathVariable( value = "taskTypeId") Long taskTypeId
@@ -40,6 +42,15 @@ public class TaskTypeController {
         UpdateTaskTypeResponseDTO updatedTakType =
                 taskTypeService.updateTaskTypeByTaskTypeId(taskTypeId, updateTaskTypeRequestDTO);
         return ResponseDTO.ok(updatedTakType);
+    }
+
+    // 과제 유형 삭제
+    @DeleteMapping("/{taskTypeId}")
+    public ResponseDTO<String> deleteTaskTypeByTaskTypeId(
+            @PathVariable( value = "taskTypeId") Long taskTypeId
+    ) {
+        taskTypeService.deleteTaskTypeByTaskTypeId(taskTypeId);
+        return ResponseDTO.ok("과제 유형 삭제가 완료되었습니다.");
     }
 
 

--- a/src/main/java/com/pado/inflow/evaluation/command/application/service/TaskTypeService.java
+++ b/src/main/java/com/pado/inflow/evaluation/command/application/service/TaskTypeService.java
@@ -9,4 +9,6 @@ public interface TaskTypeService {
     CreateTaskTypeResponseDTO createTaskTypeByTaskTypeName(CreateTaskTypeRequestDTO createTaskTypeRequestDTO);
 
     UpdateTaskTypeResponseDTO updateTaskTypeByTaskTypeId(Long taskTypeId, UpdateTaskTypeRequestDTO updateTaskTypeRequestDTO);
+
+    void deleteTaskTypeByTaskTypeId(Long taskTypeId);
 }

--- a/src/main/java/com/pado/inflow/evaluation/command/domain/aggregate/dto/request/DeleteTaskTypeRequestDTO.java
+++ b/src/main/java/com/pado/inflow/evaluation/command/domain/aggregate/dto/request/DeleteTaskTypeRequestDTO.java
@@ -1,0 +1,18 @@
+package com.pado.inflow.evaluation.command.domain.aggregate.dto.request;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.pado.inflow.evaluation.command.domain.aggregate.entity.TaskTypeEntity;
+import lombok.Data;
+
+@Data
+public class DeleteTaskTypeRequestDTO {
+    @JsonProperty("task_type_name")
+    private String taskTypeName;
+
+    // DTO to Entity
+    public TaskTypeEntity toEntity() {
+        return TaskTypeEntity.builder()
+                .taskTypeName(this.taskTypeName)
+                .build();
+    }
+}

--- a/src/main/java/com/pado/inflow/evaluation/command/domain/aggregate/dto/response/DeleteTaskTypeResponseDTO.java
+++ b/src/main/java/com/pado/inflow/evaluation/command/domain/aggregate/dto/response/DeleteTaskTypeResponseDTO.java
@@ -1,0 +1,19 @@
+package com.pado.inflow.evaluation.command.domain.aggregate.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+
+@Data
+public class DeleteTaskTypeResponseDTO {
+
+    @JsonProperty("task_type_id")
+    private Long taskTypeId;
+
+    @JsonProperty("task_type_name")
+    private String taskTypeName;
+
+    public DeleteTaskTypeResponseDTO(Long taskTypeId, String taskTypeName) {
+        this.taskTypeId = taskTypeId;
+        this.taskTypeName = taskTypeName;
+    }
+}

--- a/src/main/java/com/pado/inflow/evaluation/command/domain/repository/TaskTypeRepository.java
+++ b/src/main/java/com/pado/inflow/evaluation/command/domain/repository/TaskTypeRepository.java
@@ -19,4 +19,5 @@ public interface TaskTypeRepository extends JpaRepository<TaskTypeEntity, Long> 
     // 특정 TaskType에 연결된 모든 EvaluationPolicy를 반환
     @Query("SELECT e FROM EvaluationPolicyEntity e WHERE e.taskType.taskTypeId = :taskTypeId")
     List<EvaluationPolicyEntity> findEvaluationsPoliciesByTaskTypeId(Long taskTypeId);
+
 }

--- a/src/main/java/com/pado/inflow/evaluation/query/controller/EvaluationController.java
+++ b/src/main/java/com/pado/inflow/evaluation/query/controller/EvaluationController.java
@@ -10,7 +10,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController("queryEvaluationController")
-@RequestMapping("/api/evaluation/evaluations")
+@RequestMapping("/api/evaluations/evaluation")
 public class EvaluationController {
 
     @Autowired

--- a/src/main/java/com/pado/inflow/evaluation/query/controller/EvaluationPolicyController.java
+++ b/src/main/java/com/pado/inflow/evaluation/query/controller/EvaluationPolicyController.java
@@ -9,7 +9,7 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 @RestController("queryEvaluationPolicyController")
-@RequestMapping("/api/evaluation/evaluationPolicy")
+@RequestMapping("/api/evaluations/evaluationPolicy")
 public class EvaluationPolicyController {
 
     @Autowired
@@ -19,6 +19,7 @@ public class EvaluationPolicyController {
         this.evaluationPolicyService = evaluationPolicyService;
     }
 
+    // 평가 정책 리스트 조회
     @GetMapping("/find")
     public ResponseDTO<?> findEvaluationPolicyByYearAndHalf(
             @RequestParam(value = "year") Integer year,
@@ -29,6 +30,7 @@ public class EvaluationPolicyController {
         return ResponseDTO.ok(selectedEvaluationPolicy);
     }
 
+    // 평가 정책 단건 조회
     @GetMapping("/{evaluationPolicyId}")
     public ResponseDTO<?> findEvaluationPolicyByevaluationPolicyId(
             @PathVariable( value = "evaluationPolicyId") Long evaluationPolicyId

--- a/src/main/java/com/pado/inflow/evaluation/query/controller/FeedbackController.java
+++ b/src/main/java/com/pado/inflow/evaluation/query/controller/FeedbackController.java
@@ -9,7 +9,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController("queryFeedbackController")
-@RequestMapping("/api/evaluation/feedback")
+@RequestMapping("/api/evaluations/feedback")
 public class FeedbackController {
 
     private final FeedbackService feedbackService;

--- a/src/main/java/com/pado/inflow/evaluation/query/controller/GradeController.java
+++ b/src/main/java/com/pado/inflow/evaluation/query/controller/GradeController.java
@@ -8,7 +8,7 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 @RestController("queryGradeController")
-@RequestMapping("/api/evaluation/grade")
+@RequestMapping("/api/evaluations/grade")
 public class GradeController {
 
     private final GradeService gradeService;

--- a/src/main/java/com/pado/inflow/evaluation/query/controller/TaskEvalController.java
+++ b/src/main/java/com/pado/inflow/evaluation/query/controller/TaskEvalController.java
@@ -10,7 +10,7 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 @RestController("queryTaskEvalController")
-@RequestMapping("/api/evaluation/taskEval")
+@RequestMapping("/api/evaluations/taskEval")
 public class TaskEvalController {
 
     private final TaskEvalService taskEvalService;

--- a/src/main/java/com/pado/inflow/evaluation/query/controller/TaskItemController.java
+++ b/src/main/java/com/pado/inflow/evaluation/query/controller/TaskItemController.java
@@ -10,7 +10,7 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 @RestController("queryTaskItemController")
-@RequestMapping("/api/evaluation/taskItem")
+@RequestMapping("/api/evaluations/taskItem")
 public class TaskItemController {
 
     @Autowired
@@ -20,7 +20,7 @@ public class TaskItemController {
         this.taskItemService = taskItemService;
     }
 
-    // 부서 과제 항목 조회
+    // 부서 과제 항목 리스트 조회
     @GetMapping("/departmentTask")
     public ResponseDTO<?> findDepartmentTaskItemByEmpId(
             @RequestParam( value = "year")  Integer year
@@ -31,6 +31,8 @@ public class TaskItemController {
                 taskItemService.findTaskItemByEmpIdAndYearAndHalf(year, half, empId);
         return ResponseDTO.ok(TaskItemList);
     }
+
+    // 부서 과제 항목 단건 조회
 
     // 개인 과제 항목 리스트 조회
     @GetMapping("/individualTasks")
@@ -49,22 +51,25 @@ public class TaskItemController {
     public ResponseDTO<?> findIndividualTeskByTaskItemId(
             @PathVariable Long taskItemId
     ) {
-        TaskItemDTO taskItem = taskItemService.findIndividualTaskItemByTaskItemId(taskItemId);
+        TaskItemDTO taskItem =
+                taskItemService.findIndividualTaskItemByTaskItemId(taskItemId);
         return ResponseDTO.ok(taskItem);
     }
 
-    // 공통 과제 조회
-    @GetMapping("/commonTask")
+    // 공통 과제 항목 리스트 조회
+    @GetMapping("/commonTasks")
     public ResponseDTO<?> findCommonTaskItemByEmpId(
             @RequestParam( value = "year") Integer year
            ,@RequestParam( value = "half") String half
             ,@RequestParam( value = "empId") Long empId
     ) {
-        List<TaskItemDTO> CommonTaskList = taskItemService.getCommonTaskItem(year, half, empId);
+        List<TaskItemDTO> CommonTaskList =
+                taskItemService.getCommonTaskItem(year, half, empId);
 
         return ResponseDTO.ok(CommonTaskList);
 
     }
 
+    //공통 과제 항목 단건 조회
 }
 

--- a/src/main/java/com/pado/inflow/evaluation/query/controller/TaskTypeController.java
+++ b/src/main/java/com/pado/inflow/evaluation/query/controller/TaskTypeController.java
@@ -10,7 +10,7 @@ import org.springframework.web.bind.annotation.RestController;
 import java.util.List;
 
 @RestController("queryTaskTypeController")
-@RequestMapping("/api/evaluation/taskTypes")
+@RequestMapping("/api/evaluations/taskType")
 public class TaskTypeController {
 
 
@@ -21,7 +21,7 @@ public class TaskTypeController {
     }
 
     // 과제 유형 조회
-    @GetMapping
+    @GetMapping("/allTaskType")
     public ResponseDTO<?> findTaskType() {
         List<TaskTypeDTO> taskTypes = taskTypeService.findAllTaskTypes();
         return ResponseDTO.ok(taskTypes);


### PR DESCRIPTION
---
name: 기능 개발 이슈
assignees: ''

---

## 어떤 부분에 리뷰어가 집중하면 좋은가
-  과제 유형 삭제 기능입니다. PathVariable로 받은 해당 과제 유형이 존재하는지, 또한 존재한다면 그 과제는 다른 평가 정책에 엮여서 사용중인지 여부를 판단합니다.
두 경우를 모두 통과한다면 정상적으로 삭제됩니다.

또한 API별 WebSecurity에 권한을 설정하였습니다. 
설정된 권한별 Postman에서 모두 테스트를 마쳤습니다. 

또한 과제 유형 로직에 필요한 에러코드를 2개 추가하였습니다.
TASK_TYPE_UPDATE_FAILURE
TASK_TYPE_DELETE_FAILURE 

## 무슨 이유로 코드를 개발했는가
- [ ] 신규 기능
- [ ] 기능 수정
- [ ] 버그 픽스
- [ ] 테스트

## 어떤 위험이나 장애가 발견되었는지 (버그 픽스인 경우)
- 
- 

## 관련 스크린 샷 
![image](https://github.com/user-attachments/assets/f4d106de-b9b1-4dfc-ad9b-cf1e31dfff15)
![image](https://github.com/user-attachments/assets/d0fde82e-4c2b-4d25-94d2-af0b70f5ea9d)
![image](https://github.com/user-attachments/assets/9467e627-d165-4f98-bb44-4b059fabfb16)

## 테스트 계획 또는 완료 사항(테스트인 경우)
- [ ] 테스트항목 1
- [ ] 테스트항목 2

## 소스코드1
```Java


```

## 상세 설명
- 

## 닫은 이슈(기능)
close #
