### PR TITLE
Refactor: 리프레시 토큰을 통한 액세스 토큰 재발급 로직 수정

### DIFF
--- a/src/main/java/com/pado/inflow/employee/security/AuthenticationFilter.java
+++ b/src/main/java/com/pado/inflow/employee/security/AuthenticationFilter.java
@@ -153,14 +153,14 @@ public class AuthenticationFilter extends UsernamePasswordAuthenticationFilter {
         String accessToken = Jwts.builder()
                 .setClaims(claims)
                 .setExpiration(new Date(accessExpiration))
-                .signWith(SignatureAlgorithm.HS512, env.getProperty("token.secret"))
+                .signWith(SignatureAlgorithm.HS512, env.getProperty("token.access-secret"))
                 .compact();
 
         // 리프레시 토큰 생성
         String refreshToken = Jwts.builder()
                 .setClaims(claims)
                 .setExpiration(new Date(refreshExpiration))
-                .signWith(SignatureAlgorithm.HS512, env.getProperty("token.secret"))
+                .signWith(SignatureAlgorithm.HS512, env.getProperty("token.refresh-secret"))
                 .compact();
 
         // 로그인 응답 객체 생성

--- a/src/main/java/com/pado/inflow/employee/security/JwtFilter.java
+++ b/src/main/java/com/pado/inflow/employee/security/JwtFilter.java
@@ -40,8 +40,8 @@ public class JwtFilter extends OncePerRequestFilter {
         log.info("Request URI: {}", requestURI);
 
         // 로그인 요청은 필터를 통과시킴
-        if ("/api/login".equals(requestURI) || "/api/register".equals(requestURI)) {
-            log.info("로그인/회원가입 요청은 필터를 통과합니다.");
+        if ("/api/login".equals(requestURI) || "/api/auth/refresh-token".equals(requestURI)) {
+            log.info("로그인/리프레시 재발급 요청은 필터를 통과합니다.");
             filterChain.doFilter(request, response);
             return;
         }
@@ -73,7 +73,7 @@ public class JwtFilter extends OncePerRequestFilter {
             log.info("토큰 값: " + token);
 
             try {
-                if (jwtUtil.validateToken(token)) {
+                if (jwtUtil.validateAccessToken(token)) {
                     Authentication authentication = jwtUtil.getAuthentication(token);
                     SecurityContextHolder.getContext().setAuthentication(authentication);
                     log.info("JwtFilter를 통과한 유효한 토큰을 통해 security가 관리할 principal 객체: {}", authentication);

--- a/src/main/java/com/pado/inflow/employee/security/JwtUtil.java
+++ b/src/main/java/com/pado/inflow/employee/security/JwtUtil.java
@@ -28,21 +28,27 @@ import java.util.stream.Collectors;
 @Component
 public class JwtUtil {
 
-    private final Key secretKey;
+    private final Key accessSecretKey;
+    private final Key refreshSecretKey;
     private final long accessExpirationTime;
     private final long refreshExpirationTime;
     private final EmployeeCommandService employeeService;
     private final EmployeeRepository employeeRepository;
 
     public JwtUtil(
-            @Value("${token.secret}") String secretKey,
+            @Value("${token.access-secret}") String accessSecretKey,
+            @Value("${token.refresh-secret}") String refreshSecretKey,
             @Value("${token.access-expiration-time}") long accessExpirationTime,
             @Value("${token.refresh-expiration-time}") long refreshExpirationTime,
             EmployeeCommandService employeeService,
             EmployeeRepository employeeRepository
     ) {
-        byte[] keyBytes = Decoders.BASE64.decode(secretKey);
-        this.secretKey = Keys.hmacShaKeyFor(keyBytes);
+        byte[] accessKeyBytes = Decoders.BASE64.decode(accessSecretKey);
+        this.accessSecretKey = Keys.hmacShaKeyFor(accessKeyBytes);
+
+        byte[] refreshKeyBytes = Decoders.BASE64.decode(refreshSecretKey);
+        this.refreshSecretKey = Keys.hmacShaKeyFor(refreshKeyBytes);
+
         this.accessExpirationTime = accessExpirationTime;
         this.refreshExpirationTime = refreshExpirationTime;
         this.employeeService = employeeService;
@@ -50,19 +56,18 @@ public class JwtUtil {
     }
 
     // 설명. 리프레시 토큰으로 액세스 토큰 재발급하는 로직 처리
+    // 설명. 리프레시 토큰으로 액세스 토큰 재발급
     public AuthTokens refreshAccessToken(String refreshToken) {
-        if (!validateToken(refreshToken)) {
+        if (!validateRefreshToken(refreshToken)) {
             throw new CommonException(ErrorCode.EXPIRED_TOKEN_ERROR);
         }
 
-        String employeeNumber = getEmployeeNumber(refreshToken);
+        String employeeNumber = getEmployeeNumberFromRefresh(refreshToken);
 
         Employee employee = employeeRepository.findByEmployeeNumber(employeeNumber)
                 .orElseThrow(() -> new CommonException(ErrorCode.NOT_FOUND_EMPLOYEE));
 
-        String role = employee.getEmployeeRole().name();
-        String newAccessToken = generateToken(employee, Collections.singletonList(role));
-        log.info("employee: ", employee);
+        String newAccessToken = generateAccessToken(employee);
 
         return new AuthTokens(
                 newAccessToken,
@@ -75,29 +80,57 @@ public class JwtUtil {
         );
     }
 
-    // 설명. Token 검증 메소드
-    public boolean validateToken(String token) {
+    // 설명. 액세스 토큰 생성
+    public String generateAccessToken(Employee employee) {
+        return Jwts.builder()
+                .setSubject(employee.getEmployeeNumber())
+                .claim("auth", List.of("ROLE_" + employee.getEmployeeRole().name()))
+                .claim("employeeId", employee.getEmployeeId())
+                .claim("employeeNumber", employee.getEmployeeNumber())
+                .setIssuedAt(new Date())
+                .setExpiration(new Date(System.currentTimeMillis() + accessExpirationTime))
+                .signWith(accessSecretKey, SignatureAlgorithm.HS512)
+                .compact();
+    }
+
+    // 설명. 리프레시 토큰 생성
+    public String generateRefreshToken(Employee employee) {
+        return Jwts.builder()
+                .setSubject(employee.getEmployeeNumber())
+                .claim("employeeId", employee.getEmployeeId())
+                .setIssuedAt(new Date())
+                .setExpiration(new Date(System.currentTimeMillis() + refreshExpirationTime))
+                .signWith(refreshSecretKey, SignatureAlgorithm.HS512)
+                .compact();
+    }
+
+
+
+    // 설명. 액세스 토큰 검증
+    public boolean validateAccessToken(String token) {
         try {
-            Jwts.parserBuilder().setSigningKey(secretKey).build().parseClaimsJws(token);
+            Jwts.parserBuilder().setSigningKey(accessSecretKey).build().parseClaimsJws(token);
             return true;
-        } catch (io.jsonwebtoken.security.SecurityException | MalformedJwtException e) {
-            log.info("Invalid JWT Token {}", e.getMessage());
+        } catch (JwtException e) {
+            log.info("Invalid Access Token: {}", e.getMessage());
             throw new CommonException(ErrorCode.INVALID_TOKEN_ERROR);
-        } catch (ExpiredJwtException e) {
-            log.info("Expired JWT Token {}", e.getMessage());
-            throw new CommonException(ErrorCode.EXPIRED_TOKEN_ERROR);
-        } catch (UnsupportedJwtException e) {
-            log.info("Unsupported JWT Token {}", e.getMessage());
-            throw new CommonException(ErrorCode.TOKEN_UNSUPPORTED_ERROR);
-        } catch (IllegalArgumentException e) {
-            log.info("JWT Token claims empty {}", e.getMessage());
-            throw new CommonException(ErrorCode.TOKEN_MALFORMED_ERROR);
+        }
+    }
+
+    // 설명. 리프레시 토큰 검증
+    public boolean validateRefreshToken(String token) {
+        try {
+            Claims claims = Jwts.parserBuilder().setSigningKey(refreshSecretKey).build().parseClaimsJws(token).getBody();
+            return true;
+        } catch (JwtException e) {
+            log.info("Invalid Refresh Token: {}", e.getMessage());
+            throw new CommonException(ErrorCode.INVALID_TOKEN_ERROR);
         }
     }
 
     // 설명. Token에서 인증 객체 추출
     public Authentication getAuthentication(String token) {
-        String employeeNumber = this.getEmployeeNumber(token);
+        String employeeNumber = this.getEmployeeNumberFromAccess(token);
         UserDetails userDetails  = employeeService.loadUserByUsername(employeeNumber);
 
         Claims claims = parseClaims(token);
@@ -118,27 +151,19 @@ public class JwtUtil {
         return new UsernamePasswordAuthenticationToken(userDetails, "", authorities);
     }
 
-    // 설명. Token에서 Claims 추출
+    // 설명. accessToken에서 Claims 추출
     public Claims parseClaims(String token) {
-        return Jwts.parserBuilder().setSigningKey(secretKey).build().parseClaimsJws(token).getBody();
+        return Jwts.parserBuilder().setSigningKey(accessSecretKey).build().parseClaimsJws(token).getBody();
     }
 
-    // 설명. Token에서 employeeNumber 추출
-    public String getEmployeeNumber(String token) {
-        return parseClaims(token).getSubject();
+    // 설명. 토큰에서 employeeNumber 추출 (액세스 토큰)
+    public String getEmployeeNumberFromAccess(String token) {
+        return Jwts.parserBuilder().setSigningKey(accessSecretKey).build().parseClaimsJws(token).getBody().getSubject();
     }
 
-    // 설명. 액세스 토큰 생성 메소드
-    public String generateToken(Employee employee, List<String> roles) {
-        return Jwts.builder()
-                .setSubject(employee.getEmployeeNumber()) // 사번(employeeNumber)로 식별
-                .claim("auth", roles)
-                .claim( "employeeId",employee.getEmployeeId())
-                .claim("employeeNumber", employee.getEmployeeNumber())
-                .setIssuedAt(new Date())
-                .setExpiration(new Date(System.currentTimeMillis() + accessExpirationTime))
-                .signWith(secretKey, SignatureAlgorithm.HS512)
-                .compact();
+    // 설명. 토큰에서 employeeNumber 추출 (리프레시 토큰)
+    public String getEmployeeNumberFromRefresh(String token) {
+        return Jwts.parserBuilder().setSigningKey(refreshSecretKey).build().parseClaimsJws(token).getBody().getSubject();
     }
 
     // 설명. 액세스 토큰 만료 시간 가져오기


### PR DESCRIPTION
---
name: 리프레시 토큰을 통한 액세스 토큰 재발급 로직 수정
assignees: '조창욱'

---

## 무슨 이유로 코드를 개발했는가
- [x] 신규 기능
- [ ] 기능 수정
- [ ] 버그 픽스
- [ ] 테스트

## 소스코드1
```Java
  // 설명. 액세스 토큰 생성
    public String generateAccessToken(Employee employee) {
        return Jwts.builder()
                .setSubject(employee.getEmployeeNumber())
                .claim("auth", List.of("ROLE_" + employee.getEmployeeRole().name()))
                .claim("employeeId", employee.getEmployeeId())
                .claim("employeeNumber", employee.getEmployeeNumber())
                .setIssuedAt(new Date())
                .setExpiration(new Date(System.currentTimeMillis() + accessExpirationTime))
                .signWith(accessSecretKey, SignatureAlgorithm.HS512)
                .compact();
    }

    // 설명. 리프레시 토큰 생성
    public String generateRefreshToken(Employee employee) {
        return Jwts.builder()
                .setSubject(employee.getEmployeeNumber())
                .claim("employeeId", employee.getEmployeeId())
                .setIssuedAt(new Date())
                .setExpiration(new Date(System.currentTimeMillis() + refreshExpirationTime))
                .signWith(refreshSecretKey, SignatureAlgorithm.HS512)
                .compact();
    }

```

## 상세 설명
- 리프레시 토큰은 권한이 따로 없고, 토큰 재발급을 위해서만 사용하도록 수정
