### PR TITLE
Refactor: 부서 상세정보 조회, 현존하는 부서만 조회되도록 조건문 추가

### DIFF
--- a/src/main/resources/com/pado/inflow/department/query/repository/DepartmentMapper.xml
+++ b/src/main/resources/com/pado/inflow/department/query/repository/DepartmentMapper.xml
@@ -227,6 +227,29 @@
     <!-- 설명. 1. 부서 코드를 통해 부서 정보 상세 조회 -> 다시해야함 (인사 기본 테이블 조인)-->
     <!-- 부서 코드를 통해 해당 부서 코드의 부서명/부서코드/상위부서명/최소인원수/부서장을 조회할 수 있다. -->
     <!-- 상위 부서의 경우 최소 인원수는 하위 부서들의 최소 인원수 합 -->
+<!--    <select id="findDepartmentDetailByDepartmentCode"-->
+<!--            resultType="com.pado.inflow.department.query.dto.DepartmentDetailDTO">-->
+<!--        SELECT-->
+<!--            d.department_name AS departmentName,-->
+<!--            d.department_code AS departmentCode,-->
+<!--            ud.department_name AS upperDepartmentName,-->
+<!--            d.min_employee_num AS minEmployeeNum,-->
+<!--            dm.name AS departmentHeadName-->
+<!--          FROM-->
+<!--            department d-->
+<!--        LEFT JOIN-->
+<!--            department ud-->
+<!--        ON-->
+<!--            d.upper_department_code = ud.department_code-->
+<!--        LEFT JOIN-->
+<!--            (SELECT *-->
+<!--            FROM department_member-->
+<!--            WHERE role_name = '부서장') dm-->
+<!--        ON-->
+<!--            d.department_code = dm.department_code-->
+<!--        WHERE-->
+<!--            d.department_code = #{departmentCode}-->
+<!--    </select>-->
     <select id="findDepartmentDetailByDepartmentCode"
             resultType="com.pado.inflow.department.query.dto.DepartmentDetailDTO">
         SELECT
@@ -237,9 +260,9 @@
             dm.name AS departmentHeadName
           FROM
             department d
-        LEFT JOIN
+          LEFT JOIN
             department ud
-        ON
+          ON
             d.upper_department_code = ud.department_code
         LEFT JOIN
             (SELECT *
@@ -249,6 +272,7 @@
             d.department_code = dm.department_code
         WHERE
             d.department_code = #{departmentCode}
+        AND (d.disbanded_at IS NULL OR d.disbanded_at > NOW())
     </select>
 
 

--- a/src/main/resources/com/pado/inflow/department/query/repository/DepartmentMapper.xml
+++ b/src/main/resources/com/pado/inflow/department/query/repository/DepartmentMapper.xml
@@ -226,30 +226,6 @@
     <!-- **** 인사팀 권한  - 부서 관리 **** -->
     <!-- 설명. 1. 부서 코드를 통해 부서 정보 상세 조회 -> 다시해야함 (인사 기본 테이블 조인)-->
     <!-- 부서 코드를 통해 해당 부서 코드의 부서명/부서코드/상위부서명/최소인원수/부서장을 조회할 수 있다. -->
-    <!-- 상위 부서의 경우 최소 인원수는 하위 부서들의 최소 인원수 합 -->
-<!--    <select id="findDepartmentDetailByDepartmentCode"-->
-<!--            resultType="com.pado.inflow.department.query.dto.DepartmentDetailDTO">-->
-<!--        SELECT-->
-<!--            d.department_name AS departmentName,-->
-<!--            d.department_code AS departmentCode,-->
-<!--            ud.department_name AS upperDepartmentName,-->
-<!--            d.min_employee_num AS minEmployeeNum,-->
-<!--            dm.name AS departmentHeadName-->
-<!--          FROM-->
-<!--            department d-->
-<!--        LEFT JOIN-->
-<!--            department ud-->
-<!--        ON-->
-<!--            d.upper_department_code = ud.department_code-->
-<!--        LEFT JOIN-->
-<!--            (SELECT *-->
-<!--            FROM department_member-->
-<!--            WHERE role_name = '부서장') dm-->
-<!--        ON-->
-<!--            d.department_code = dm.department_code-->
-<!--        WHERE-->
-<!--            d.department_code = #{departmentCode}-->
-<!--    </select>-->
     <select id="findDepartmentDetailByDepartmentCode"
             resultType="com.pado.inflow.department.query.dto.DepartmentDetailDTO">
         SELECT


### PR DESCRIPTION
---
name: 부서 상세정보 조회, 현존하는 부서만 조회되도록 조건문 추가

---

## 어떤 부분에 리뷰어가 집중하면 좋은가
- 

## 무슨 이유로 코드를 개발했는가
- [ ] 신규 기능
- [x] 기능 수정
- [ ] 버그 픽스
- [ ] 테스트


## 관련 스크린 샷 
<img width="1155" alt="스크린샷 2024-11-26 오후 6 42 44" src="https://github.com/user-attachments/assets/e0226c22-b848-41c9-8b4b-9484cf0d461f">

## 소스코드1
```xml

    <!-- **** 인사팀 권한  - 부서 관리 **** -->
    <!-- 설명. 1. 부서 코드를 통해 부서 정보 상세 조회 -> 다시해야함 (인사 기본 테이블 조인)-->
    <!-- 부서 코드를 통해 해당 부서 코드의 부서명/부서코드/상위부서명/최소인원수/부서장을 조회할 수 있다. -->
    <select id="findDepartmentDetailByDepartmentCode"
            resultType="com.pado.inflow.department.query.dto.DepartmentDetailDTO">
        SELECT
            d.department_name AS departmentName,
            d.department_code AS departmentCode,
            ud.department_name AS upperDepartmentName,
            d.min_employee_num AS minEmployeeNum,
            dm.name AS departmentHeadName
          FROM
            department d
          LEFT JOIN
            department ud
          ON
            d.upper_department_code = ud.department_code
        LEFT JOIN
            (SELECT *
            FROM department_member
            WHERE role_name = '부서장') dm
        ON
            d.department_code = dm.department_code
        WHERE
            d.department_code = #{departmentCode}
        AND (d.disbanded_at IS NULL OR d.disbanded_at > NOW())
    </select>



```

## 상세 설명
- 소프트 딜리트 된 부서 조회되지 않도록 조건문 추가

