### PR TITLE
Fix: s3 저장 실패시 트랜잭션 롤백되도록 수정

### DIFF
--- a/src/main/java/com/pado/inflow/attendance/command/application/service/AttendanceRequestServiceImpl.java
+++ b/src/main/java/com/pado/inflow/attendance/command/application/service/AttendanceRequestServiceImpl.java
@@ -462,20 +462,23 @@ public class AttendanceRequestServiceImpl implements AttendanceRequestService {
         AttendanceRequest leaveRequest =
                 attendanceRequestRepository.save(modelMapper.map(resLeaveReturnRequestDTO, AttendanceRequest.class));
 
+        // 파일 업로드 및 DB 저장 처리
         if (reqLeaveRequestDTO.getAttachments() != null && !reqLeaveRequestDTO.getAttachments().isEmpty()) {
-            // 첨부 파일 DB 저장
-            for (MultipartFile file : reqLeaveRequestDTO.getAttachments()) {
+            try {
+                for (MultipartFile file : reqLeaveRequestDTO.getAttachments()) {
+                    String fileUrl = attendanceS3Service.uploadFile(file, leaveRequest.getEmployeeId());
+                    ResponseAttendanceRequestFileDTO resAttendanceRequestFileDTO = ResponseAttendanceRequestFileDTO
+                            .builder()
+                            .fileName(file.getOriginalFilename())
+                            .fileUrl(fileUrl)
+                            .attendanceRequestId(leaveRequest.getAttendanceRequestId())
+                            .build();
 
-                String fileUrl = attendanceS3Service.uploadFile(file, leaveRequest.getEmployeeId());
-
-                ResponseAttendanceRequestFileDTO resAttendanceRequestFileDTO = ResponseAttendanceRequestFileDTO
-                        .builder()
-                        .fileName(file.getOriginalFilename())
-                        .fileUrl(fileUrl)
-                        .attendanceRequestId(leaveRequest.getAttendanceRequestId())
-                        .build();
-
-                attendanceRequestFileRepository.save(modelMapper.map(resAttendanceRequestFileDTO, AttendanceRequestFile.class));
+                    attendanceRequestFileRepository.save(modelMapper.map(resAttendanceRequestFileDTO, AttendanceRequestFile.class));
+                }
+            } catch (Exception e) {
+                // 파일 업로드 실패 시 트랜잭션 롤백
+                throw new CommonException(ErrorCode.FILE_UPLOAD_FAILED);
             }
         }
 
@@ -564,20 +567,23 @@ public class AttendanceRequestServiceImpl implements AttendanceRequestService {
         AttendanceRequest returnRequest =
                 attendanceRequestRepository.save(modelMapper.map(resLeaveReturnDTO, AttendanceRequest.class));
 
+        // 파일 업로드 및 DB 저장 처리
         if (reqReturnRequestDTO.getAttachments() != null && !reqReturnRequestDTO.getAttachments().isEmpty()) {
-            // 첨부 파일 DB 저장
-            for (MultipartFile file : reqReturnRequestDTO.getAttachments()) {
+            try {
+                for (MultipartFile file : reqReturnRequestDTO.getAttachments()) {
+                    String fileUrl = attendanceS3Service.uploadFile(file, returnRequest.getEmployeeId());
+                    ResponseAttendanceRequestFileDTO resAttendanceRequestFileDTO = ResponseAttendanceRequestFileDTO
+                            .builder()
+                            .fileName(file.getOriginalFilename())
+                            .fileUrl(fileUrl)
+                            .attendanceRequestId(returnRequest.getAttendanceRequestId())
+                            .build();
 
-                String fileUrl = attendanceS3Service.uploadFile(file, returnRequest.getEmployeeId());
-
-                ResponseAttendanceRequestFileDTO resAttendanceRequestFileDTO = ResponseAttendanceRequestFileDTO
-                        .builder()
-                        .fileName(file.getOriginalFilename())
-                        .fileUrl(fileUrl)
-                        .attendanceRequestId(returnRequest.getAttendanceRequestId())
-                        .build();
-
-                attendanceRequestFileRepository.save(modelMapper.map(resAttendanceRequestFileDTO, AttendanceRequestFile.class));
+                    attendanceRequestFileRepository.save(modelMapper.map(resAttendanceRequestFileDTO, AttendanceRequestFile.class));
+                }
+            } catch (Exception e) {
+                // 파일 업로드 실패 시 트랜잭션 롤백
+                throw new CommonException(ErrorCode.FILE_UPLOAD_FAILED);
             }
         }
 

--- a/src/main/java/com/pado/inflow/attendance/command/application/service/AttendanceRequestServiceImpl.java
+++ b/src/main/java/com/pado/inflow/attendance/command/application/service/AttendanceRequestServiceImpl.java
@@ -478,7 +478,7 @@ public class AttendanceRequestServiceImpl implements AttendanceRequestService {
                 }
             } catch (Exception e) {
                 // 파일 업로드 실패 시 트랜잭션 롤백
-                throw new CommonException(ErrorCode.FILE_UPLOAD_FAILED);
+                throw new CommonException(ErrorCode.FILE_UPLOAD_ERROR);
             }
         }
 

--- a/src/main/java/com/pado/inflow/attendance/command/application/service/AttendanceRequestServiceImpl.java
+++ b/src/main/java/com/pado/inflow/attendance/command/application/service/AttendanceRequestServiceImpl.java
@@ -583,7 +583,7 @@ public class AttendanceRequestServiceImpl implements AttendanceRequestService {
                 }
             } catch (Exception e) {
                 // 파일 업로드 실패 시 트랜잭션 롤백
-                throw new CommonException(ErrorCode.FILE_UPLOAD_FAILED);
+                throw new CommonException(ErrorCode.FILE_UPLOAD_ERROR);
             }
         }
 

--- a/src/main/java/com/pado/inflow/common/exception/ErrorCode.java
+++ b/src/main/java/com/pado/inflow/common/exception/ErrorCode.java
@@ -136,7 +136,7 @@ public enum ErrorCode {
     INTERNAL_SERVER_ERROR(50000, HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류입니다"),
     PASSWORD_ENCODING_FAILED(50001, HttpStatus.INTERNAL_SERVER_ERROR, "비밀번호 암호화 실패"),
     SmsSendingException(50002, HttpStatus.INTERNAL_SERVER_ERROR, "SMS 전송 실패"),
-    MAX_UPLOAD_SIZE_EXCEEDED(50003, HttpStatus.INTERNAL_SERVER_ERROR, "업로드 실패: 파일의 크기가 너무 큽니다."),
+    MAX_UPLOAD_SIZE_EXCEEDED(50003, HttpStatus.INTERNAL_SERVER_ERROR, "업로드 실패: 파일의 크기가 너무 큽니다.");
 
     private final Integer code;
     private final HttpStatus httpStatus;

--- a/src/main/java/com/pado/inflow/common/exception/ErrorCode.java
+++ b/src/main/java/com/pado/inflow/common/exception/ErrorCode.java
@@ -137,7 +137,6 @@ public enum ErrorCode {
     PASSWORD_ENCODING_FAILED(50001, HttpStatus.INTERNAL_SERVER_ERROR, "비밀번호 암호화 실패"),
     SmsSendingException(50002, HttpStatus.INTERNAL_SERVER_ERROR, "SMS 전송 실패"),
     MAX_UPLOAD_SIZE_EXCEEDED(50003, HttpStatus.INTERNAL_SERVER_ERROR, "업로드 실패: 파일의 크기가 너무 큽니다."),
-    FILE_UPLOAD_FAILED(50004, HttpStatus.INTERNAL_SERVER_ERROR, "파일 저장 실패");
 
     private final Integer code;
     private final HttpStatus httpStatus;

--- a/src/main/java/com/pado/inflow/common/exception/ErrorCode.java
+++ b/src/main/java/com/pado/inflow/common/exception/ErrorCode.java
@@ -136,7 +136,8 @@ public enum ErrorCode {
     INTERNAL_SERVER_ERROR(50000, HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류입니다"),
     PASSWORD_ENCODING_FAILED(50001, HttpStatus.INTERNAL_SERVER_ERROR, "비밀번호 암호화 실패"),
     SmsSendingException(50002, HttpStatus.INTERNAL_SERVER_ERROR, "SMS 전송 실패"),
-    MAX_UPLOAD_SIZE_EXCEEDED(50003, HttpStatus.INTERNAL_SERVER_ERROR, "업로드 실패: 파일의 크기가 너무 큽니다.");
+    MAX_UPLOAD_SIZE_EXCEEDED(50003, HttpStatus.INTERNAL_SERVER_ERROR, "업로드 실패: 파일의 크기가 너무 큽니다."),
+    FILE_UPLOAD_FAILED(50004, HttpStatus.INTERNAL_SERVER_ERROR, "파일 저장 실패");
 
     private final Integer code;
     private final HttpStatus httpStatus;

--- a/src/main/java/com/pado/inflow/vacation/command/application/service/VacationRequestServiceImpl.java
+++ b/src/main/java/com/pado/inflow/vacation/command/application/service/VacationRequestServiceImpl.java
@@ -118,18 +118,22 @@ public class VacationRequestServiceImpl implements VacationRequestService {
 
         if (reqVacationRequestDTO.getAttachments() != null && !reqVacationRequestDTO.getAttachments().isEmpty()) {
             // 첨부 파일 DB 저장
-            for (MultipartFile file : reqVacationRequestDTO.getAttachments()) {
+            try {
+                for (MultipartFile file : reqVacationRequestDTO.getAttachments()) {
 
-                String fileUrl = vacationS3Service.uploadFile(file, vacationRequest.getEmployeeId());
+                    String fileUrl = vacationS3Service.uploadFile(file, vacationRequest.getEmployeeId());
 
-                ResponseVacationRequestFileDTO resVacationRequestFileDTO = ResponseVacationRequestFileDTO
-                        .builder()
-                        .fileName(file.getOriginalFilename())
-                        .fileUrl(fileUrl)
-                        .vacationRequestId(vacationRequest.getVacationRequestId())
-                        .build();
+                    ResponseVacationRequestFileDTO resVacationRequestFileDTO = ResponseVacationRequestFileDTO
+                            .builder()
+                            .fileName(file.getOriginalFilename())
+                            .fileUrl(fileUrl)
+                            .vacationRequestId(vacationRequest.getVacationRequestId())
+                            .build();
 
-                vacationRequestFileRepository.save(modelMapper.map(resVacationRequestFileDTO, VacationRequestFile.class));
+                    vacationRequestFileRepository.save(modelMapper.map(resVacationRequestFileDTO, VacationRequestFile.class));
+                }
+            } catch (Exception e) {
+                throw new CommonException(ErrorCode.FILE_UPLOAD_FAILED);
             }
         }
 

--- a/src/main/java/com/pado/inflow/vacation/command/application/service/VacationRequestServiceImpl.java
+++ b/src/main/java/com/pado/inflow/vacation/command/application/service/VacationRequestServiceImpl.java
@@ -133,7 +133,7 @@ public class VacationRequestServiceImpl implements VacationRequestService {
                     vacationRequestFileRepository.save(modelMapper.map(resVacationRequestFileDTO, VacationRequestFile.class));
                 }
             } catch (Exception e) {
-                throw new CommonException(ErrorCode.FILE_UPLOAD_FAILED);
+                throw new CommonException(ErrorCode.FILE_UPLOAD_ERROR);
             }
         }
 


### PR DESCRIPTION
---
name: 기능 개발 이슈
assignees: ''

---

## 어떤 부분에 리뷰어가 집중하면 좋은가
- 

## 무슨 이유로 코드를 개발했는가
- [ ] 신규 기능
- [ ] 기능 수정
- [x] 버그 픽스
- [ ] 테스트

## 어떤 위험이나 장애가 발견되었는지 (버그 픽스인 경우)
-  s3 저장 실패시에도 db에는 저장되는 버그
- 

## 관련 스크린 샷 

## 소스코드
```Java
        if (reqVacationRequestDTO.getAttachments() != null && !reqVacationRequestDTO.getAttachments().isEmpty()) {
            // 첨부 파일 DB 저장
            try {
                for (MultipartFile file : reqVacationRequestDTO.getAttachments()) {

                    String fileUrl = vacationS3Service.uploadFile(file, vacationRequest.getEmployeeId());

                    ResponseVacationRequestFileDTO resVacationRequestFileDTO = ResponseVacationRequestFileDTO
                            .builder()
                            .fileName(file.getOriginalFilename())
                            .fileUrl(fileUrl)
                            .vacationRequestId(vacationRequest.getVacationRequestId())
                            .build();

                    vacationRequestFileRepository.save(modelMapper.map(resVacationRequestFileDTO, VacationRequestFile.class));
                }
            } catch (Exception e) {
                throw new CommonException(ErrorCode.FILE_UPLOAD_ERROR);
            }
        }

```

## 상세 설명
- 

## 닫은 이슈(기능)
close #
